### PR TITLE
Support GHC >=7

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,8 @@ jobs:
         include:
           - ghc: 9.0.1
             allow-failure: false
+          - ghc: 8.10.3
+            allow-failure: false
           - ghc: 8.8.4
             allow-failure: false
           - ghc: 8.4.4

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -26,13 +26,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: 8.10.3
-            allow-failure: false
           - ghc: 8.8.4
             allow-failure: false
-          - ghc: 8.4.3
+          - ghc: 8.4.4
             allow-failure: false
           - ghc: 8.0.2
+            allow-failure: false
+          - ghc: 7.8.4
+            allow-failure: false
+          - ghc: 7.4.2
+            allow-failure: false
+          - ghc: 7.0.4
             allow-failure: false
       fail-fast: false
     steps:

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - ghc: 9.0.1
+            allow-failure: false
           - ghc: 8.8.4
             allow-failure: false
           - ghc: 8.4.4
@@ -35,8 +37,6 @@ jobs:
           - ghc: 7.8.4
             allow-failure: false
           - ghc: 7.4.2
-            allow-failure: false
-          - ghc: 7.0.4
             allow-failure: false
       fail-fast: false
     steps:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Changes in version 0.2.3
 
-- Support GHC 7.0 by conditionally removing the `Strict` flag for GHC versions < 8.
+- Support GHC >= 7.4 by conditionally removing  strictness features (the `Strict` flag and strict `IntMap`s) for GHC versions < 8.
 
 ## Changes in version 0.2.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
+## Changes in version 0.2.3
+
+- Support GHC 7.0 by conditionally removing the `Strict` flag.
+
 ## Changes in version 0.2.2.1
 
-Adjust codebase for ! parsing changes.
+- Adjust codebase for ! parsing changes.
 
 ## Changes in version 0.2.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Changes in version 0.2.3
 
-- Support GHC 7.0 by conditionally removing the `Strict` flag.
+- Support GHC 7.0 by conditionally removing the `Strict` flag for GHC versions < 8.
 
 ## Changes in version 0.2.2.1
 

--- a/Data/Graph/Dom.hs
+++ b/Data/Graph/Dom.hs
@@ -473,7 +473,7 @@ toEdges = concatMap (uncurry (fmap . (,))) . toAdj
 predG :: Graph -> Graph
 predG g = IM.unionWith IS.union (go g) g0
   where g0 = fmap (const mempty) g
-        go = flip foldrWithKey mempty (\i a m ->
+        go = flip IM.foldrWithKey mempty (\i a m ->
                 foldl' (\m p -> IM.insertWith mappend p
                                       (IS.singleton i) m)
                         m
@@ -552,7 +552,7 @@ collectI (<>) f g
 -- (renamed, old -> new)
 renum :: Int -> Graph -> (Graph, NodeMap Node)
 renum from = (\(_,m,g)->(g,m))
-  . foldrWithKey
+  . IM.foldrWithKey
       (\i ss (!n,!env,!new)->
           let (j,n2,env2) = go n env i
               (n3,env3,ss2) = IS.fold
@@ -615,9 +615,3 @@ fetch f i = do
 -- Redefine Data.Bifunctor.second for GHC 7 compatibility
 second :: (b -> c) -> (a, b) -> (a, c)
 second f (a, b) = (a, f b)
-
-#if __GLASGOW_HASKELL__ >= 704
-foldrWithKey = IM.foldrWithKey
-#else
-foldrWithKey f z = foldr (uncurry f) z . IM.toAscList
-#endif

--- a/Data/Graph/Dom.hs
+++ b/Data/Graph/Dom.hs
@@ -52,11 +52,18 @@ import Data.Tree
 import Data.List
 import Data.IntMap(IntMap)
 import Data.IntSet(IntSet)
-import qualified Data.IntMap.Strict as IM
 import qualified Data.IntSet as IS
 
+import Control.Applicative
 import Control.Monad
+
+#if __GLASGOW_HASKELL__ >= 800
+import qualified Data.IntMap.Strict as IM
 import Control.Monad.ST.Strict
+#else
+import qualified Data.IntMap as IM
+import Control.Monad.ST
+#endif
 
 import Data.Array.ST
 import Data.Array.Base

--- a/Data/Graph/Dom.hs
+++ b/Data/Graph/Dom.hs
@@ -46,7 +46,6 @@ module Data.Graph.Dom (
 ) where
 
 import Data.Monoid(Monoid(..))
-import Data.Bifunctor
 import Data.Tuple (swap)
 
 import Data.Tree
@@ -605,3 +604,7 @@ fetch :: (MArray (A z) a (ST z))
 fetch f i = do
   a <- gets f
   st (a!:i)
+
+-- Redefine Data.Bifunctor.second for GHC 7 compatibility
+second :: (b -> c) -> (a, b) -> (a, c)
+second f (a, b) = (a, f b)

--- a/Data/Graph/Dom.hs
+++ b/Data/Graph/Dom.hs
@@ -57,7 +57,7 @@ import qualified Data.IntSet as IS
 import Control.Applicative
 import Control.Monad
 
-#if __GLASGOW_HASKELL__ >= 800
+#if MIN_VERSION_containers(0, 5, 0)
 import qualified Data.IntMap.Strict as IM
 import Control.Monad.ST.Strict
 #else

--- a/Data/Graph/Dom.hs
+++ b/Data/Graph/Dom.hs
@@ -1,4 +1,9 @@
-{-# LANGUAGE RankNTypes, BangPatterns, FlexibleContexts, Strict #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes, BangPatterns, FlexibleContexts #-}
+
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE Strict #-}
+#endif
 
 {- |
   Module      :  Data.Graph.Dom
@@ -600,29 +605,3 @@ fetch :: (MArray (A z) a (ST z))
 fetch f i = do
   a <- gets f
   st (a!:i)
-
------------------------------------------------------------------------------
-
--- g0 = fromAdj
---   [(1,[2,3])
---   ,(2,[3])
---   ,(3,[4])
---   ,(4,[3,5,6])
---   ,(5,[7])
---   ,(6,[7])
---   ,(7,[4,8])
---   ,(8,[3,9,10])
---   ,(9,[1])
---   ,(10,[7])]
-
--- g1 = fromAdj
---   [(0,[1])
---   ,(1,[2,3])
---   ,(2,[7])
---   ,(3,[4])
---   ,(4,[5,6])
---   ,(5,[7])
---   ,(6,[4])
---   ,(7,[])]
-
------------------------------------------------------------------------------

--- a/Data/Graph/Dom.hs
+++ b/Data/Graph/Dom.hs
@@ -473,7 +473,7 @@ toEdges = concatMap (uncurry (fmap . (,))) . toAdj
 predG :: Graph -> Graph
 predG g = IM.unionWith IS.union (go g) g0
   where g0 = fmap (const mempty) g
-        go = flip IM.foldrWithKey mempty (\i a m ->
+        go = flip foldrWithKey mempty (\i a m ->
                 foldl' (\m p -> IM.insertWith mappend p
                                       (IS.singleton i) m)
                         m
@@ -552,7 +552,7 @@ collectI (<>) f g
 -- (renamed, old -> new)
 renum :: Int -> Graph -> (Graph, NodeMap Node)
 renum from = (\(_,m,g)->(g,m))
-  . IM.foldrWithKey
+  . foldrWithKey
       (\i ss (!n,!env,!new)->
           let (j,n2,env2) = go n env i
               (n3,env3,ss2) = IS.fold
@@ -615,3 +615,9 @@ fetch f i = do
 -- Redefine Data.Bifunctor.second for GHC 7 compatibility
 second :: (b -> c) -> (a, b) -> (a, c)
 second f (a, b) = (a, f b)
+
+#if __GLASGOW_HASKELL__ >= 704
+foldrWithKey = IM.foldrWithKey
+#else
+foldrWithKey f z = foldr (uncurry f) z . IM.toAscList
+#endif

--- a/Data/Graph/Dom/Internal.hs
+++ b/Data/Graph/Dom/Internal.hs
@@ -22,8 +22,8 @@ asDotFile :: D.Graph -> String
 asDotFile g =
     let pprNode :: (Int, IntSet) -> String
         pprNode (node,targets) =
-            concat $ intersperse newline $ fmap (pprEdge node) $ IS.toList targets
+            F.concat $ intersperse newline $ fmap (pprEdge node) $ IS.toList targets
         pprEdge v u = show v ++ " -> " ++ show u ++ ";"
     in "digraph G {" ++ newline ++
-            (concat $ intersperse newline $ fmap pprNode (IM.toList g)) ++ newline ++
+            (F.concat $ intersperse newline $ fmap pprNode (IM.toList g)) ++ newline ++
             "}"

--- a/Data/Graph/Dom/Internal.hs
+++ b/Data/Graph/Dom/Internal.hs
@@ -4,7 +4,7 @@ module Data.Graph.Dom.Internal where
 
 import Data.Graph.Dom as D
 
-#if __GLASGOW_HASKELL__ >= 800
+#if MIN_VERSION_containers(0, 5, 0)
 import Data.IntMap.Strict as IM
 #else
 import Data.IntMap as IM

--- a/Data/Graph/Dom/Internal.hs
+++ b/Data/Graph/Dom/Internal.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE CPP #-}
+
 module Data.Graph.Dom.Internal where
 
 import Data.Graph.Dom as D
 
+#if __GLASGOW_HASKELL__ >= 800
+import Data.IntMap.Strict as IM
+#else
+import Data.IntMap as IM
+#endif
+
 import Data.Foldable as F
 import Data.List
-import Data.IntMap.Strict as IM
 import Data.IntSet as IS
 
 newline :: [Char]

--- a/dom-lt.cabal
+++ b/dom-lt.cabal
@@ -38,7 +38,7 @@ library
   build-depends:
       base >= 4.3 && < 5
     , array
-    , containers
+    , containers >= 0.4.2.0 && < 0.7
   exposed-modules:
     Data.Graph.Dom,
     Data.Graph.Dom.Internal

--- a/dom-lt.cabal
+++ b/dom-lt.cabal
@@ -17,7 +17,7 @@ description:
     Included are ways to compute domination and post-domination relationships.
 
 tested-with:
-  GHC == 8.10.3 || == 8.8.4 || == 8.4.3 || == 8.0.2
+  GHC == 8.10.3 || == 8.8.4 || == 8.4.3 || == 8.0.2 || == 7.10.3 || == 7.0.1
 
 Extra-Source-Files:
   Changelog.md
@@ -35,7 +35,7 @@ library
   ghc-options:      -O2 -funbox-strict-fields
   default-extensions: RankNTypes
   build-depends:
-      base >= 4.9 && < 5
+      base >= 4.3 && < 5
     , array
     , containers >= 0.5 && < 0.7
   exposed-modules:
@@ -50,7 +50,7 @@ test-suite dom-lt-tests
   hs-source-dirs: tests
 
   build-depends:
-      base                        >=4.6   && <5
+      base                        >=4.3   && <5
     , dom-lt
     , containers
     , HUnit                       >=1.3   && <1.7

--- a/dom-lt.cabal
+++ b/dom-lt.cabal
@@ -1,5 +1,5 @@
 name:               dom-lt
-version:            0.2.2.1
+version:            0.2.3
 cabal-version:      >= 1.10
 build-type:         Simple
 license:            BSD3

--- a/dom-lt.cabal
+++ b/dom-lt.cabal
@@ -18,7 +18,7 @@ description:
 
 tested-with:
   -- Every two major versions between 7 and 9 should be enough
-  GHC == 9.0.1 || == 8.8.4 || == 8.4.4 || == 8.0.2 || == 7.8.4 || == 7.4.2 || == 7.0.4
+  GHC == 9.0.1 || == 8.8.4 || == 8.4.4 || == 8.0.2 || == 7.8.4 || == 7.4.2
 
 Extra-Source-Files:
   Changelog.md

--- a/dom-lt.cabal
+++ b/dom-lt.cabal
@@ -38,7 +38,7 @@ library
   build-depends:
       base >= 4.3 && < 5
     , array
-    , containers >= 0.5 && < 0.7
+    , containers
   exposed-modules:
     Data.Graph.Dom,
     Data.Graph.Dom.Internal
@@ -66,7 +66,7 @@ benchmark dom-lt-bench
   Main-Is:  Main.hs
   hs-source-dirs: benchmarks
 
-  Build-Depends: base, dom-lt, containers, criterion >= 1.4, deepseq
+  Build-Depends: base, dom-lt, containers, criterion, deepseq
   default-extensions:
 
   Ghc-Options: -O2 -fno-full-laziness

--- a/dom-lt.cabal
+++ b/dom-lt.cabal
@@ -18,7 +18,7 @@ description:
 
 tested-with:
   -- Every two major versions between 7 and 9 should be enough
-  GHC == 9.0.1 || == 8.8.4 || == 8.4.4 || == 8.0.2 || == 7.8.4 || == 7.4.2
+  GHC == 9.0.1 || == 8.10.3 || == 8.8.4 || == 8.4.4 || == 8.0.2 || == 7.8.4 || == 7.4.2
 
 Extra-Source-Files:
   Changelog.md

--- a/dom-lt.cabal
+++ b/dom-lt.cabal
@@ -17,7 +17,8 @@ description:
     Included are ways to compute domination and post-domination relationships.
 
 tested-with:
-  GHC == 8.10.3 || == 8.8.4 || == 8.4.3 || == 8.0.2 || == 7.10.3 || == 7.0.1
+  -- Every two major versions between 7 and 9 should be enough
+  GHC == 9.0.1 || == 8.8.4 || == 8.4.4 || == 8.0.2 || == 7.8.4 || == 7.4.2 || == 7.0.4
 
 Extra-Source-Files:
   Changelog.md

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ >= 800
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
+#endif
 
 module Main (main) where
 


### PR DESCRIPTION
As the `-XStrict` flag was only introduced in GHC 8, this MR supports GHC 7 by removing the `-XStrict` flag for GHC < 8.

This MR also bumps the version to 0.2.3 to allow importing dom-lt in happy.

@sgraf812