### PR TITLE
fix: clear processed dominator buckets

### DIFF
--- a/Data/Graph/Dom.hs
+++ b/Data/Graph/Dom.hs
@@ -178,6 +178,7 @@ idomM = do
     pw <- parentM w
     link pw w
     bps <- bucketM pw
+    modify(\e->e{bucketE=IM.insert pw mempty (bucketE e)})
     forM_ bps (\v-> do
       u <- eval v
       su <- sdnoM u

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -32,9 +32,12 @@ g1 = (0,
         ,(7,[])]
     )
 
+star :: Int -> Rooted
+star n = (0, fromAdj $ (0, [1..n-1]) : [(i, []) | i <- [1..n-1]])
+
 -- Our benchmark harness.
 main :: IO ()
-main = g0 `deepseq` g1 `deepseq`
+main = g0 `deepseq` g1 `deepseq` star 20000 `deepseq`
     defaultMain [
         bgroup "g0" [ bench "dom"       $ nf dom g0
                     , bench "pdom"      $ nf pdom g0
@@ -49,5 +52,8 @@ main = g0 `deepseq` g1 `deepseq`
                     , bench "ipdom"     $ nf ipdom g1
                     , bench "domTree"   $ nf domTree g1
                     , bench "pdomTree"  $ nf pdomTree g1
+            ],
+        bgroup "star-20000" [ bench "idom" $ nf idom (star 20000)
+                            , bench "dom"  $ nf dom (star 20000)
             ]
         ]


### PR DESCRIPTION
Clear `bucket[parent[w]]` after it has been processed in the LT pass. 
Without this, old entries remain in the bucket and can be scanned again for later DFS siblings. On a star graph this gives quadratic behavior even though the graph is sparse.

Benchmark on a star graph:
| nodes | before | after |
|---:|---:|---:|
| 1,000 | 0.007944s | 0.000837s |
| 2,000 | 0.029925s | 0.001424s |
| 4,000 | 0.120069s | 0.003496s |
| 8,000 | 0.466351s | 0.006931s |
| 12,000 | 1.052579s | 0.010818s |
| 20,000 | 2.809345s | 0.020091s |
| 40,000 | 11.987663s | 0.044862s |